### PR TITLE
Correct create clock constrain mistakes in nuclei-master.xdc

### DIFF
--- a/fpga/ddr200t/constrs/nuclei-master.xdc
+++ b/fpga/ddr200t/constrs/nuclei-master.xdc
@@ -6,10 +6,10 @@ set_property CONFIG_VOLTAGE 3.3 [current_design]
 
 
 set_property -dict { PACKAGE_PIN W19    IOSTANDARD LVCMOS33 } [get_ports { CLK100MHZ }]; 
-create_clock -add -name sys_clk_pin -period 10.00 -waveform {0 5} [get_ports {CLK100MHZ}];
+create_clock -add -name sys_clk_100M -period 10.00 -waveform {0 5} [get_ports {CLK100MHZ}];
 
 set_property -dict { PACKAGE_PIN Y18    IOSTANDARD LVCMOS33 } [get_ports { CLK32768KHZ }]; 
-create_clock -add -name sys_clk_pin -period 30517.58 -waveform {0 15258.79} [get_ports {CLK32768KHZ}];
+create_clock -add -name sys_clk_32768KHZ -period 30517.58 -waveform {0 15258.79} [get_ports {CLK32768KHZ}];
 
 
 set_property CLOCK_DEDICATED_ROUTE FALSE [get_nets dut_io_pads_jtag_TCK_i_ival]

--- a/fpga/mcu200t/constrs/nuclei-master.xdc
+++ b/fpga/mcu200t/constrs/nuclei-master.xdc
@@ -6,10 +6,10 @@ set_property CONFIG_VOLTAGE 3.3 [current_design]
 
 
 set_property -dict { PACKAGE_PIN W19    IOSTANDARD LVCMOS33 } [get_ports { CLK100MHZ }]; 
-create_clock -add -name sys_clk_pin -period 10.00 -waveform {0 5} [get_ports {CLK100MHZ}];
+create_clock -add -name sys_clk_100M -period 10.00 -waveform {0 5} [get_ports {CLK100MHZ}];
 
 set_property -dict { PACKAGE_PIN Y18    IOSTANDARD LVCMOS33 } [get_ports { CLK32768KHZ }]; 
-create_clock -add -name sys_clk_pin -period 30517.58 -waveform {0 15258.79} [get_ports {CLK32768KHZ}];
+create_clock -add -name sys_clk_32768KHZ -period 30517.58 -waveform {0 15258.79} [get_ports {CLK32768KHZ}];
 
 
 set_property CLOCK_DEDICATED_ROUTE FALSE [get_nets dut_io_pads_jtag_TCK_i_ival]


### PR DESCRIPTION
In cons file line 9,12 of nuclei-master.xdc, two create_clock -name sys_clk_pin have the same clock name from two different clock port.
在约束文件nuclei-master.xdc 9行和12行，两句create clock约束从快时钟和慢时钟两个管脚上约束的时钟重名了，这是一个很明显的错误，使用-add选项也是同一个管脚设定不同的频率，而不是两个管脚设定同一个时钟，显然100M的约束会被覆盖掉