### PR TITLE
Fix compilation error on Ubuntu 22.04

### DIFF
--- a/vsim/bin/run.makefile
+++ b/vsim/bin/run.makefile
@@ -128,7 +128,7 @@ wave:
 run: compile
 	rm -rf ${TEST_RUNDIR}
 	mkdir ${TEST_RUNDIR}
-	cd ${TEST_RUNDIR}; ${SIM_EXEC} +DUMPWAVE=${DUMPWAVE} +TESTCASE=${TESTCASE} +SIM_TOOL=${SIM_TOOL} |& tee ${TESTNAME}.log; cd ${RUN_DIR}; 
+	cd ${TEST_RUNDIR}; ${SIM_EXEC} +DUMPWAVE=${DUMPWAVE} +TESTCASE=${TESTCASE} +SIM_TOOL=${SIM_TOOL} 2>&1 | tee ${TESTNAME}.log; cd ${RUN_DIR}; 
 
 
 .PHONY: run clean all 


### PR DESCRIPTION
Default /bin/sh does not support '|&', change into portable '2>&1 |' to fix build errors like below:

>cd rv32ui-p-add; vvp /work/e203_hbirdv2/vsim/run/vvp.exec -lxt2   +DUMPWAVE=1 +TESTCASE=/work/e203_hbirdv2/vsim/run/../../riscv-tools/riscv-tests/isa/generated/rv32ui-p-add +SIM_TOOL=iverilog |& tee rv32ui-p-add.log; cd /work/e203_hbirdv2/vsim/run;
>/bin/sh: 1: Syntax error: "&" unexpected
>make[1]: *** [Makefile:131: run] Error 2