### PR TITLE
Add default case to UART APB write logic

### DIFF
--- a/rtl/e203/perips/apb_uart/apb_uart.v
+++ b/rtl/e203/perips/apb_uart/apb_uart.v
@@ -206,6 +206,7 @@ module apb_uart_sv
                     tx_fifo_clr_n   = PWDATA[2];
                     trigger_level_n = PWDATA[7:6];
                 end
+                default: ; // No operation for undefined addresses
             endcase
         end
 


### PR DESCRIPTION
This PR adds a default case to the APB write logic in the UART peripheral.

**Changes:**
- Added a `default` case in the `case (register_adr)` block inside APB write logic.

**Reason:**
- Prevents unintended behavior when an undefined address is accessed.
- Avoids potential latch inference issues.
- Improves robustness and coding style.

**Impact:**
- No functional changes to existing UART behavior.
- Safe and backward compatible.
- Only affects handling of invalid register addresses.

**Notes:**
- Default case performs no operation (`default: ;`).


- Follows best RTL design practices for complete case statement coverage.