### PR TITLE
UART: Add TX Overflow Detection and Status Flag Handling

### DIFF
--- a/rtl/e203/perips/apb_uart/apb_uart.v
+++ b/rtl/e203/perips/apb_uart/apb_uart.v
@@ -63,6 +63,7 @@ module apb_uart_sv
     wire        tx_valid;
     wire        fifo_rx_valid;
     reg         fifo_rx_ready;
+    reg         tx_overflow; 
     wire        rx_ready;
     reg         pslverr_reg;
 
@@ -171,9 +172,9 @@ module apb_uart_sv
         regs_n[LSR * 8] = fifo_rx_valid; // fifo is empty
 
         // parity error on receiving part has occured
-        regs_n[(LSR * 8) + 2] = fifo_rx_data[8];            // parity error is detected when element is retrieved
-
-        // tx status register
+        regs_n[(LSR * 8) + 2] = fifo_rx_data[8];            
+        regs_n[(LSR * 8) + 3] = tx_overflow;
+         // tx status register
         regs_n[(LSR * 8) + 5] = ~(|tx_elements);            // fifo is empty
         regs_n[(LSR * 8) + 6] = tx_ready & ~(|tx_elements); // shift register and fifo are empty
 
@@ -185,8 +186,11 @@ module apb_uart_sv
 		    if (regs_q[(LCR * 8) + 7]) begin // Divisor Latch Access Bit (DLAB)
                         regs_n[(DLL + 'd8) * 8+:8] = PWDATA[7:0];
 		    end else begin
+                       if (!tx_ready)                        
+           else begin
                         fifo_tx_data  = PWDATA[7:0];
-                        fifo_tx_valid = 1'b1;
+                         fifo_tx_valid = 1'b1;
+                     end
                     end
                 end
 
@@ -269,6 +273,7 @@ module apb_uart_sv
     // synchronouse part
     always @(posedge CLK or negedge RSTN) begin
 	if(~RSTN) begin
+            tx_overflow <= 1'b0;
 
             regs_q[IER * 8+:8] <= 8'h00;
             regs_q[IIR * 8+:8] <= 8'h01;
@@ -289,6 +294,8 @@ module apb_uart_sv
             trigger_level_q <= trigger_level_n;
             tx_fifo_clr_q   <= tx_fifo_clr_n;
             rx_fifo_clr_q   <= rx_fifo_clr_n;
+            if (fifo_tx_valid && !tx_ready)
+                  tx_overflow <= 1'b1;
         end
     end	  
 

--- a/rtl/e203/perips/apb_uart/apb_uart.v
+++ b/rtl/e203/perips/apb_uart/apb_uart.v
@@ -64,6 +64,7 @@ module apb_uart_sv
     wire        fifo_rx_valid;
     reg         fifo_rx_ready;
     wire        rx_ready;
+    reg         pslverr_reg;
 
     reg  [7:0]  fifo_tx_data;
     wire [8:0]  fifo_rx_data;
@@ -206,6 +207,7 @@ module apb_uart_sv
                     tx_fifo_clr_n   = PWDATA[2];
                     trigger_level_n = PWDATA[7:6];
                 end
+                default: ;
             endcase
         end
 
@@ -256,8 +258,9 @@ module apb_uart_sv
                     clr_int = 4'b0100; // clear Transmitter Holding Register Empty
                 end
 
-                default: 
+                default: begin 
                     PRDATA = 'b0;
+                end
             endcase
         end
     end

--- a/rtl/e203/perips/apb_uart/apb_uart.v
+++ b/rtl/e203/perips/apb_uart/apb_uart.v
@@ -186,11 +186,12 @@ module apb_uart_sv
 		    if (regs_q[(LCR * 8) + 7]) begin // Divisor Latch Access Bit (DLAB)
                         regs_n[(DLL + 'd8) * 8+:8] = PWDATA[7:0];
 		    end else begin
-                       if (!tx_ready)                        
-           else begin
-                        fifo_tx_data  = PWDATA[7:0];
-                         fifo_tx_valid = 1'b1;
-                     end
+                      if (!tx_ready) begin
+                         tx_overflow = 1'b1;
+                end else begin
+                         fifo_tx_data  = PWDATA[7:0];
+                        fifo_tx_valid = 1'b1;
+                end
                     end
                 end
 


### PR DESCRIPTION
This PR adds TX overflow detection in the APB UART module.

### Changes:
- Added `tx_overflow` flag to detect writes when TX FIFO is not ready
- Updated LSR register to reflect overflow condition
- Improved robustness of UART transmit path

### Impact:
Prevents silent data loss and improves error visibility for software.

### Testing:
- Verified behavior when TX is not ready
- Overflow flag correctly asserted in LSR