### PR TITLE
Add PSLVERR support for invalid APB transactions in UART

### DIFF
--- a/rtl/e203/perips/apb_uart/apb_uart.v
+++ b/rtl/e203/perips/apb_uart/apb_uart.v
@@ -261,6 +261,7 @@ module apb_uart_sv
                 default:  begin
                     PRDATA = 'b0;
                     pslverr_reg = 1'b1;
+                end
             endcase
         end
     end

--- a/rtl/e203/perips/apb_uart/apb_uart.v
+++ b/rtl/e203/perips/apb_uart/apb_uart.v
@@ -159,6 +159,7 @@ module apb_uart_sv
     // UART Registers
     // register write and update logic
     always @(*) begin
+        pslverr_reg = 1'b0;
         regs_n          = regs_q;
         trigger_level_n = trigger_level_q;
 
@@ -214,6 +215,7 @@ module apb_uart_sv
 
     // register read logic
     always @(*) begin
+        pslverr_reg   = 1'0;
         PRDATA        = 'b0;
         apb_rx_ready  = 1'b0;
         fifo_rx_ready = 1'b0;
@@ -256,8 +258,9 @@ module apb_uart_sv
                     clr_int = 4'b0100; // clear Transmitter Holding Register Empty
                 end
 
-                default: 
+                default:  begin
                     PRDATA = 'b0;
+                    pslverr_reg = 1'b1;
             endcase
         end
     end
@@ -277,6 +280,7 @@ module apb_uart_sv
             regs_q[(DLM + 'd8) * 8+:8] <= 8'h00;
             regs_q[(DLL + 'd8) * 8+:8] <= 8'h00;
 
+            pslverr_reg       <= 1'b0;
             trigger_level_q   <= 2'b00;
             tx_fifo_clr_q     <= 1'b0;
             rx_fifo_clr_q     <= 1'b0;
@@ -294,6 +298,6 @@ module apb_uart_sv
     // APB logic: we are always ready to capture the data into our regs
     // not supporting transfare failure
     assign PREADY       = 1'b1;
-    assign PSLVERR      = 1'b0;
+    assign PSLVERR      = pslverr_reg;
 
 endmodule


### PR DESCRIPTION
Add PSLVERR support to UART APB interface for invalid accesses.

- Added error register
- Handled invalid read/write cases
- Improved APB compliance